### PR TITLE
Update to version 2 of META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -51,6 +51,7 @@ copyright = 1
 [ModuleBuildTiny]
 [MakeMaker::Fallback]
 [MetaYAML]
+version = 2
 [Readme]
 [Manifest] ; should come last
 


### PR DESCRIPTION
This will properly define Test::TCP as a test requirement, NOT a build requirement and will therefore not be installed by carton.
